### PR TITLE
 supports the delete tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Request new Spot Instances
 
 Tagging to EC2 instance
 
+### `ec2c untag`
+
+Delete tag from the specified EC2 instance
+
 ### `ec2c terminate`
 
 Terminate the specified EC2 instance

--- a/command/untag.go
+++ b/command/untag.go
@@ -49,13 +49,9 @@ func (c *UntagCommand) Run(args []string) int {
 	}
 
 	for _, tag := range strings.Split(tagString, ",") {
-		keyValue := strings.Split(tag, "=")
-
-		if len(keyValue) == 1 {
-			tags = append(tags, &ec2.Tag{
-				Key: aws.String(keyValue[0]),
-			})
-		}
+		tags = append(tags, &ec2.Tag{
+			Key: aws.String(tag),
+		})
 	}
 
 	opts := &ec2.DeleteTagsInput{

--- a/command/untag.go
+++ b/command/untag.go
@@ -33,7 +33,7 @@ func (c *UntagCommand) Run(args []string) int {
 
 	flags.BoolVar(&dryRun, "dry-run", false, "Dry run (default: false)")
 	flags.StringVar(&instanceIDString, "instance", "", "Instance Ids")
-	flags.StringVar(&tagString, "tags", "", "KEY=VALUE tags")
+	flags.StringVar(&tagString, "tags", "", "KEY tags")
 
 	if err := flags.Parse(args[0:]); err != nil {
 		return 1
@@ -53,13 +53,7 @@ func (c *UntagCommand) Run(args []string) int {
 
 		if len(keyValue) == 1 {
 			tags = append(tags, &ec2.Tag{
-				Key:   aws.String(keyValue[0]),
-				Value: aws.String(""),
-			})
-		} else {
-			tags = append(tags, &ec2.Tag{
-				Key:   aws.String(keyValue[0]),
-				Value: aws.String(strings.Join(keyValue[1:], "=")),
+				Key: aws.String(keyValue[0]),
 			})
 		}
 	}

--- a/command/untag.go
+++ b/command/untag.go
@@ -1,0 +1,90 @@
+package command
+
+import (
+	"flag"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+type UnTagCommand struct {
+	Meta
+}
+
+func (c *UnTagCommand) Run(args []string) int {
+	var (
+		dryRun           bool
+		instanceIDString string
+		instanceIDs      []*string
+		tagString        string
+		tags             []*ec2.Tag
+	)
+
+	var (
+		arguments []string
+	)
+
+	svc := ec2.New(session.New(), &aws.Config{})
+
+	flags := flag.NewFlagSet("dtan4", flag.ContinueOnError)
+	flags.Usage = func() {}
+
+	flags.BoolVar(&dryRun, "dry-run", false, "Dry run (default: false)")
+	flags.StringVar(&instanceIDString, "instance", "", "Instance Ids")
+	flags.StringVar(&tagString, "tags", "", "KEY=VALUE tags")
+
+	if err := flags.Parse(args[0:]); err != nil {
+		return 1
+	}
+
+	for 0 < flags.NArg() {
+		arguments = append(arguments, flags.Arg(0))
+		flags.Parse(flags.Args()[1:])
+	}
+
+	for _, id := range strings.Split(instanceIDString, ",") {
+		instanceIDs = append(instanceIDs, aws.String(id))
+	}
+
+	for _, tag := range strings.Split(tagString, ",") {
+		keyValue := strings.Split(tag, "=")
+
+		if len(keyValue) == 1 {
+			tags = append(tags, &ec2.Tag{
+				Key:   aws.String(keyValue[0]),
+				Value: aws.String(""),
+			})
+		} else {
+			tags = append(tags, &ec2.Tag{
+				Key:   aws.String(keyValue[0]),
+				Value: aws.String(strings.Join(keyValue[1:], "=")),
+			})
+		}
+	}
+
+	opts := &ec2.DeleteTagsInput{
+		DryRun:    aws.Bool(dryRun),
+		Resources: instanceIDs,
+		Tags:      tags,
+	}
+
+	_, err := svc.DeleteTags(opts)
+	if err != nil {
+		panic(err)
+	}
+
+	return 0
+}
+
+func (c *UnTagCommand) Synopsis() string {
+	return "Tag EC2 instances"
+}
+
+func (c *UnTagCommand) Help() string {
+	helpText := `
+
+`
+	return strings.TrimSpace(helpText)
+}

--- a/command/untag.go
+++ b/command/untag.go
@@ -9,11 +9,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
-type UnTagCommand struct {
+type UntagCommand struct {
 	Meta
 }
 
-func (c *UnTagCommand) Run(args []string) int {
+func (c *UntagCommand) Run(args []string) int {
 	var (
 		dryRun           bool
 		instanceIDString string
@@ -78,11 +78,11 @@ func (c *UnTagCommand) Run(args []string) int {
 	return 0
 }
 
-func (c *UnTagCommand) Synopsis() string {
+func (c *UntagCommand) Synopsis() string {
 	return "Tag EC2 instances"
 }
 
-func (c *UnTagCommand) Help() string {
+func (c *UntagCommand) Help() string {
 	helpText := `
 
 `

--- a/command/untag_test.go
+++ b/command/untag_test.go
@@ -6,6 +6,6 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-func TestTagCommand_implement(t *testing.T) {
+func TestUntagCommand_implement(t *testing.T) {
 	var _ cli.Command = &TagCommand{}
 }

--- a/command/untag_test.go
+++ b/command/untag_test.go
@@ -1,0 +1,11 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/mitchellh/cli"
+)
+
+func TestTagCommand_implement(t *testing.T) {
+	var _ cli.Command = &TagCommand{}
+}

--- a/commands.go
+++ b/commands.go
@@ -37,6 +37,11 @@ func Commands(meta *command.Meta) map[string]cli.CommandFactory {
 				Meta: *meta,
 			}, nil
 		},
+		"untag": func() (cli.Command, error) {
+			return &command.UnTagCommand{
+				Meta: *meta,
+			}, nil
+		},
 		"terminate": func() (cli.Command, error) {
 			return &command.TerminateCommand{
 				Meta: *meta,

--- a/commands.go
+++ b/commands.go
@@ -38,7 +38,7 @@ func Commands(meta *command.Meta) map[string]cli.CommandFactory {
 			}, nil
 		},
 		"untag": func() (cli.Command, error) {
-			return &command.UnTagCommand{
+			return &command.UntagCommand{
 				Meta: *meta,
 			}, nil
 		},


### PR DESCRIPTION
## WHY

```
$ ec2c list | grep sample-server
i-12345asd  running m4.large                          sample-server
i-hogehoge  running m4.large  10.0.7.6  52.197.41.76  kube-server
```

`ec2c` supports the `launch` and `terminate`.
 I think that the `ec2c` should supports the delete tag.
## WHAT

Add untag command.
