### PR TITLE
Build and push Docker image on Travis CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!bin/ec2c_linux-amd64

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ ec2c
 bin/*
 
 vendor/
+
+/glide

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,19 @@
+sudo: required
+services:
+  - docker
 language: go
 go:
   - '1.5'
   - '1.6'
-install: make deps
 env:
   - GO15VENDOREXPERIMENT=1
+install:
+  - make deps
+script:
+  - make test
+deploy:
+  provider: script
+  script: make ci-docker-release
+  on:
+    branch: master
+    go: '1.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ go:
   - '1.6'
 env:
   - GO15VENDOREXPERIMENT=1
-install:
-  - make deps
 script:
   - make test
 deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.4
+MAINTAINER Daisuke Fujita <dtanshi45@gmail.com> (@dtan4)
+
+RUN apk add --no-cache --update ca-certificates
+
+COPY bin/ec2c_linux-amd64 /ec2c
+
+ENTRYPOINT ["/ec2c"]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,44 @@
-build:
-	go build -ldflags="-w" -o bin/ec2c
+VERSION := 0.1.0
+REVISION := $(shell git rev-parse --short HEAD)
+GOVERSION := $(subst go version ,,$(shell go version))
 
-deps:
-	go get github.com/Masterminds/glide
-	glide install
+BINARY := ec2c
 
-.PHONY: build deps
+SOURCES := $(shell find . -name '*.go' -type f)
+
+LDFLAGS := -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\" -X \"main.GoVersion=$(GOVERSION)\""
+
+GLIDE_VERSION := 0.11.1
+
+.DEFAULT_GOAL := bin/$(BINARY)
+
+glide:
+ifeq ($(shell uname),Darwin)
+	curl -fL https://github.com/Masterminds/glide/releases/download/v$(GLIDE_VERSION)/glide-v$(GLIDE_VERSION)-darwin-amd64.zip -o glide.zip
+	unzip glide.zip
+	mv ./darwin-amd64/glide glide
+	rm -fr ./darwin-amd64
+	rm ./glide.zip
+else
+	curl -fL https://github.com/Masterminds/glide/releases/download/v$(GLIDE_VERSION)/glide-v$(GLIDE_VERSION)-linux-amd64.zip -o glide.zip
+	unzip glide.zip
+	mv ./linux-amd64/glide glide
+	rm -fr ./linux-amd64
+	rm ./glide.zip
+endif
+
+bin/$(BINARY): deps $(SOURCES)
+	go build $(LDFLAGS) -o bin/$(BINARY)
+
+.PHONY: clean
+clean:
+	rm -rf bin/*
+	rm -rf vendor/*
+
+.PHONY: deps
+deps: glide
+	./glide install
+
+.PHONY: install
+install: deps
+	go install $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,11 @@ bin/$(BINARY): deps $(SOURCES)
 bin/$(BINARY)$(LINUX_AMD64_SUFFIX): deps $(SOURCES)
 	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o bin/$(BINARY)$(LINUX_AMD64_SUFFIX)
 
+.PHONY: ci-docker-release
+ci-docker-release: docker-build
+	@docker login -e="$(DOCKER_QUAY_EMAIL)" -u="$(DOCKER_QUAY_USERNAME)" -p="$(DOCKER_QUAY_PASSWORD)" $(DOCKER_REPOSITORY)
+	docker push $(DOCKER_IMAGE)
+
 .PHONY: clean
 clean:
 	rm -rf bin/*
@@ -59,3 +64,7 @@ docker-push:
 .PHONY: install
 install: deps
 	go install $(LDFLAGS)
+
+.PHONY: test
+test: deps
+	go test -v

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,18 @@ REVISION := $(shell git rev-parse --short HEAD)
 GOVERSION := $(subst go version ,,$(shell go version))
 
 BINARY := ec2c
+LINUX_AMD64_SUFFIX := _linux-amd64
 
 SOURCES := $(shell find . -name '*.go' -type f)
 
 LDFLAGS := -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\" -X \"main.GoVersion=$(GOVERSION)\""
 
 GLIDE_VERSION := 0.11.1
+
+DOCKER_REPOSITORY := quay.io
+DOCKER_IMAGE_NAME := $(DOCKER_REPOSITORY)/dtan4/ec2c
+DOCKER_IMAGE_TAG := latest
+DOCKER_IMAGE := $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
 
 .DEFAULT_GOAL := bin/$(BINARY)
 
@@ -30,6 +36,9 @@ endif
 bin/$(BINARY): deps $(SOURCES)
 	go build $(LDFLAGS) -o bin/$(BINARY)
 
+bin/$(BINARY)$(LINUX_AMD64_SUFFIX): deps $(SOURCES)
+	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o bin/$(BINARY)$(LINUX_AMD64_SUFFIX)
+
 .PHONY: clean
 clean:
 	rm -rf bin/*
@@ -38,6 +47,14 @@ clean:
 .PHONY: deps
 deps: glide
 	./glide install
+
+.PHONY: docker-build
+docker-build: bin/$(BINARY)$(LINUX_AMD64_SUFFIX)
+	docker build -t $(DOCKER_IMAGE) .
+
+.PHONY: docker-push
+docker-push:
+	docker push $(DOCKER_IMAGE)
 
 .PHONY: install
 install: deps


### PR DESCRIPTION
ref. #7 
## WHY

Sometimes we want Docker image of application (regardless that Go can cross-compile...).
Using `golang` official images generates fat image, so we would like to put just a built binary only.
## WHAT

Prepare `Dockerfile` for ec2c. Build and push Docker image on Travis CI.
