### PR TITLE
Handle errors properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: go
 go:
   - '1.6'
   - '1.7'
+install:
+  - make deps
 script:
   - make test
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ language: go
 go:
   - '1.6'
   - '1.7'
-env:
-  - GO15VENDOREXPERIMENT=1
 script:
   - make test
 before_deploy:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean:
 	rm -rf vendor/*
 
 .PHONY: cross-build
-cross-build: deps
+cross-build:
 	for os in darwin linux windows; do \
 		for arch in amd64 386; do \
 			GOOS=$$os GOARCH=$$arch go build $(LDFLAGS) -o dist/$$os-$$arch/$(NAME); \
@@ -72,5 +72,5 @@ install:
 	go install $(LDFLAGS)
 
 .PHONY: test
-test: deps
+test:
 	go test -v

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ NAME := ec2c
 VERSION := v0.1.1
 REVISION := $(shell git rev-parse --short HEAD)
 
+SRCS    := $(shell find . -name '*.go' -type f)
 LDFLAGS := -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\""
 
 DIST_DIRS := find * -type d -exec
@@ -13,7 +14,7 @@ DOCKER_IMAGE := $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
 
 .DEFAULT_GOAL := bin/$(NAME)
 
-bin/$(NAME): deps
+bin/$(NAME): $(SRCS)
 	go build $(LDFLAGS) -o bin/$(NAME)
 
 .PHONY: ci-docker-release
@@ -67,7 +68,7 @@ ifeq ($(shell command -v glide 2> /dev/null),)
 endif
 
 .PHONY: install
-install: deps
+install:
 	go install $(LDFLAGS)
 
 .PHONY: test

--- a/command/cancel.go
+++ b/command/cancel.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/dtan4/ec2c/msg"
 )
 
 type CancelCommand struct {
@@ -53,7 +54,8 @@ func (c *CancelCommand) Run(args []string) int {
 
 	resp, err := svc.CancelSpotInstanceRequests(opts)
 	if err != nil {
-		panic(err)
+		msg.Errorf("Failed to cancel SpotRequest. error: %s\n", err)
+		return 1
 	}
 
 	fmt.Println(resp)

--- a/command/launch.go
+++ b/command/launch.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/dtan4/ec2c/msg"
 )
 
 type LaunchCommand struct {
@@ -108,7 +109,8 @@ func (c *LaunchCommand) Run(args []string) int {
 	if userData != "" {
 		buf, err := ioutil.ReadFile(userData)
 		if err != nil {
-			panic(err)
+			msg.Errorf("Failed to read user-data. error: %s\n", err)
+			return 1
 		}
 
 		opts.UserData = aws.String(base64.StdEncoding.EncodeToString(buf))
@@ -116,7 +118,8 @@ func (c *LaunchCommand) Run(args []string) int {
 
 	resp, err := svc.RunInstances(opts)
 	if err != nil {
-		panic(err)
+		msg.Errorf("Failed to launch instance. error: %s\n", err)
+		return 1
 	}
 
 	for _, instance := range resp.Instances {

--- a/command/list.go
+++ b/command/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/dtan4/ec2c/msg"
 )
 
 type ListCommand struct {
@@ -20,7 +21,8 @@ func (c *ListCommand) Run(args []string) int {
 
 	resp, err := svc.DescribeInstances(nil)
 	if err != nil {
-		panic(err)
+		msg.Errorf("Failed to retrieve instance list. error: %s\n", err)
+		return 1
 	}
 
 	var privateIPAddress, publicIPAddress, instanceName string

--- a/command/list_requests.go
+++ b/command/list_requests.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/dtan4/ec2c/msg"
 )
 
 type ListRequestsCommand struct {
@@ -20,7 +21,8 @@ func (c *ListRequestsCommand) Run(args []string) int {
 
 	resp, err := svc.DescribeSpotInstanceRequests(nil)
 	if err != nil {
-		panic(err)
+		msg.Errorf("Failed to retrieve SpotRequest list. error: %s\n", err)
+		return 1
 	}
 
 	var instanceID, requestName string

--- a/command/request.go
+++ b/command/request.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/dtan4/ec2c/msg"
 )
 
 type RequestCommand struct {
@@ -109,7 +110,8 @@ func (c *RequestCommand) Run(args []string) int {
 	if userData != "" {
 		buf, err := ioutil.ReadFile(userData)
 		if err != nil {
-			panic(err)
+			msg.Errorf("Failed to read user-data. error: %s\n", err)
+			return 1
 		}
 
 		launchSpecification.UserData = aws.String(base64.StdEncoding.EncodeToString(buf))
@@ -124,7 +126,8 @@ func (c *RequestCommand) Run(args []string) int {
 
 	resp, err := svc.RequestSpotInstances(opts)
 	if err != nil {
-		panic(err)
+		msg.Errorf("Failed to retrieve SpotRequest list. error: %s\n", err)
+		return 1
 	}
 
 	fmt.Println(resp)

--- a/command/tag.go
+++ b/command/tag.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/dtan4/ec2c/msg"
 )
 
 type TagCommand struct {
@@ -72,7 +73,8 @@ func (c *TagCommand) Run(args []string) int {
 
 	_, err := svc.CreateTags(opts)
 	if err != nil {
-		panic(err)
+		msg.Errorf("Failed to create tag. error: %s\n", err)
+		return 1
 	}
 
 	return 0

--- a/command/terminate.go
+++ b/command/terminate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/dtan4/ec2c/msg"
 )
 
 type TerminateCommand struct {
@@ -53,7 +54,8 @@ func (c *TerminateCommand) Run(args []string) int {
 
 	resp, err := svc.TerminateInstances(opts)
 	if err != nil {
-		panic(err)
+		msg.Errorf("Failed to terminate instance. error: %s\n", err)
+		return 1
 	}
 
 	for _, instance := range resp.TerminatingInstances {

--- a/command/untag.go
+++ b/command/untag.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/dtan4/ec2c/msg"
 )
 
 type UntagCommand struct {
@@ -62,7 +63,8 @@ func (c *UntagCommand) Run(args []string) int {
 
 	_, err := svc.DeleteTags(opts)
 	if err != nil {
-		panic(err)
+		msg.Errorf("Failed to delete tag. error: %s\n", err)
+		return 1
 	}
 
 	return 0

--- a/msg/msg.go
+++ b/msg/msg.go
@@ -1,0 +1,11 @@
+package msg
+
+import (
+	"fmt"
+	"os"
+)
+
+// Errorf shows error message with the given format
+func Errorf(format string, err error) {
+	fmt.Fprintf(os.Stderr, format, err)
+}


### PR DESCRIPTION
## WHY

Currently all errors are handled with `panic`. `panic` should not be used as normal error handling in Go application.

## WHAT

Stop using `panic` and printing error message in stderr.