### PR TITLE
Add documentation for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ $ make instatll
 
 ## Usage
 
+### Configuring credentials
+
+Before using ec2c, run `aws configure` to create `~/.aws/credentials`.
+
+`~/.aws/credentials` will look like:
+
+```
+[default]
+aws_access_key_id = xxxxxxxxxx
+aws_secret_access_key = xxxxxxxxxx
+```
+
 ### `ec2c cancel`
 
 Cancel the specified EC2 Spot Instance requests

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ aws_access_key_id = xxxxxxxxxx
 aws_secret_access_key = xxxxxxxxxx
 ```
 
+In addition, you must specify the region by the environmental variable `AWS_REGION`.
+You might want to append the line to `.bash_profile` like:
+
+```
+export AWS_REGION=ap-northeast-1
+```
+
 ### `ec2c cancel`
 
 Cancel the specified EC2 Spot Instance requests

--- a/README.md
+++ b/README.md
@@ -32,22 +32,31 @@ $ make instatll
 
 ### Configuring credentials
 
-Before using ec2c, run `aws configure` to create `~/.aws/credentials`.
-
-`~/.aws/credentials` will look like:
+Before using ec2c, ensure that you have credentials in `~/.aws/credentials`, which might look like:
 
 ```
 [default]
-aws_access_key_id = xxxxxxxxxx
-aws_secret_access_key = xxxxxxxxxx
+aws_access_key_id = AKID1234567890
+aws_secret_access_key = MY-SECRET-KEY
 ```
 
-In addition, you must specify the region by the environmental variable `AWS_REGION`.
-You might want to append the line to `.bash_profile` like:
+Alternatively, you can set the following environment variables:
+
+```
+export AWS_ACCESS_KEY_ID=AKID1234567890
+export AWS_SECRET_ACCESS_KEY=MY-SECRET-KEY
+```
+
+### Configuring the region
+
+In addition to credentials, you must specify the region by the environmental variable:
 
 ```
 export AWS_REGION=ap-northeast-1
 ```
+
+Alternatively, you can enable support for the shared config `~/.aws/config`.
+See [the aws-sdk-go documentation](https://github.com/aws/aws-sdk-go#configuring-credentials) for further information.
 
 ### `ec2c cancel`
 


### PR DESCRIPTION
A new user of ec2c might be confused with README because it does not have any description about credentials.

This PR will add a small description about configuring credentials.